### PR TITLE
Finished porting for prefix "t_" files

### DIFF
--- a/latency/src/bin/r_ping.rs
+++ b/latency/src/bin/r_ping.rs
@@ -257,7 +257,7 @@ struct Opt {
     #[clap(short, long)]
     name: String,
 
-    /// name of the scenario 
+    /// name of the scenario
     #[clap(short, long)]
     scenario: String,
 

--- a/latency/src/bin/r_ping.rs
+++ b/latency/src/bin/r_ping.rs
@@ -253,9 +253,11 @@ struct Opt {
     #[clap(short, long)]
     payload: usize,
 
+    /// name of the test
     #[clap(short, long)]
     name: String,
 
+    /// name of the scenario 
     #[clap(short, long)]
     scenario: String,
 
@@ -264,7 +266,7 @@ struct Opt {
     interval: f64,
 
     /// spawn a task to receive or not
-    #[clap(long = "parallel")]
+    #[clap(long)]
     parallel: bool,
 }
 async fn parallel(opt: Opt, config: Config) {

--- a/latency/src/bin/t_ping.rs
+++ b/latency/src/bin/t_ping.rs
@@ -12,24 +12,21 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 use async_std::task;
-use std::str::FromStr;
+use clap::Parser;
 use std::any::Any;
 use std::collections::HashMap;
 use std::io::Write;
+use std::str::FromStr;
 use std::sync::{Arc, Barrier, Mutex};
 use std::time::{Duration, Instant};
-use clap::Parser;
 use zenoh::net::link::Link;
-use zenoh_protocol_core::{
-     Channel, CongestionControl, Priority, Reliability, WhatAmI, EndPoint
-};
 use zenoh::net::protocol::io::reader::{HasReader, Reader};
 use zenoh::net::protocol::io::SplitBuffer;
 use zenoh::net::protocol::io::{WBuf, ZBuf};
 use zenoh::net::protocol::proto::{Data, ZenohBody, ZenohMessage};
 use zenoh::net::transport::*;
 use zenoh_core::Result as ZResult;
-
+use zenoh_protocol_core::{Channel, CongestionControl, EndPoint, Priority, Reliability, WhatAmI};
 
 // Transport Handler for the non-blocking endpoint
 struct MySHParallel {
@@ -181,7 +178,7 @@ impl TransportPeerEventHandler for MyMHSequential {
         match message.body {
             ZenohBody::Data(Data { payload, .. }) => {
                 let mut count_bytes = [0u8; 8];
-                let mut data_reader = payload.reader(); 
+                let mut data_reader = payload.reader();
                 if data_reader.read_exact(&mut count_bytes) {
                     let count = u64::from_le_bytes(count_bytes);
                     let barrier = self.pending.lock().unwrap().remove(&count).unwrap();
@@ -223,7 +220,7 @@ struct Opt {
     #[clap(short, long)]
     name: String,
 
-    /// name of the scenario 
+    /// name of the scenario
     #[clap(short, long)]
     scenario: String,
 
@@ -244,7 +241,10 @@ async fn single(opt: Opt, whatami: WhatAmI) {
         .unwrap();
 
     // Connect to publisher
-    let session = manager.open_transport(EndPoint::from_str(opt.endpoint.as_str()).unwrap()).await.unwrap();
+    let session = manager
+        .open_transport(EndPoint::from_str(opt.endpoint.as_str()).unwrap())
+        .await
+        .unwrap();
 
     let sleep = Duration::from_secs_f64(opt.interval);
     let payload = vec![0u8; opt.payload - 8];
@@ -314,7 +314,10 @@ async fn parallel(opt: Opt, whatami: WhatAmI) {
         .unwrap();
 
     // Connect to publisher
-    let session = manager.open_transport(EndPoint::from_str(opt.endpoint.as_str()).unwrap()).await.unwrap();
+    let session = manager
+        .open_transport(EndPoint::from_str(opt.endpoint.as_str()).unwrap())
+        .await
+        .unwrap();
 
     let sleep = Duration::from_secs_f64(opt.interval);
     let payload = vec![0u8; opt.payload - 8];

--- a/latency/src/bin/t_ping.rs
+++ b/latency/src/bin/t_ping.rs
@@ -16,7 +16,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, Barrier, Mutex};
 use std::time::{Duration, Instant};
-use structopt::StructOpt;
+use clap::Parser;
 use zenoh::net::link::{EndPoint, Link};
 use zenoh::net::protocol::core::{
     whatami, Channel, CongestionControl, Priority, Reliability, ResKey, WhatAmI,
@@ -191,22 +191,35 @@ impl TransportPeerEventHandler for MyMHSequential {
     }
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "s_sub_thr")]
+#[derive(Debug, Parser)]
+#[clap(name = "t_ping")]
 struct Opt {
-    #[structopt(short = "l", long = "locator")]
-    locator: EndPoint,
-    #[structopt(short = "m", long = "mode")]
+    /// endpoint, e.g. --endpoint tcp/127.0.0.1:7447
+    #[clap(short, long)]
+    endpoint: String,
+
+    /// peer or client or router
+    #[clap(short, long)]
     mode: String,
-    #[structopt(short = "p", long = "payload")]
+
+    /// payload size (bytes)
+    #[clap(short, long)]
     payload: usize,
-    #[structopt(short = "n", long = "name")]
+
+    /// name of the test
+    #[clap(short, long)]
     name: String,
-    #[structopt(short = "s", long = "scenario")]
+
+    /// name of the scenario 
+    #[clap(short, long)]
     scenario: String,
-    #[structopt(short = "i", long = "interval")]
+
+    /// interval of sending message (sec)
+    #[clap(short, long)]
     interval: f64,
-    #[structopt(long = "parallel")]
+
+    /// spawn a task to receive or not
+    #[clap(long)]
     parallel: bool,
 }
 
@@ -339,7 +352,7 @@ async fn main() {
     env_logger::init();
 
     // Parse the args
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     let whatami = whatami::parse(opt.mode.as_str()).unwrap();
 

--- a/latency/src/bin/t_pong.rs
+++ b/latency/src/bin/t_pong.rs
@@ -13,17 +13,17 @@
 //
 use async_std::future;
 use async_std::sync::Arc;
-use std::str::FromStr;
-use std::any::Any;
 use clap::Parser;
+use std::any::Any;
+use std::str::FromStr;
 use zenoh::net::link::Link;
-use zenoh_protocol_core::{WhatAmI, EndPoint};
 use zenoh::net::protocol::proto::ZenohMessage;
 use zenoh::net::transport::{
-    TransportEventHandler, TransportManager, TransportMulticast,
-    TransportMulticastEventHandler, TransportPeer, TransportPeerEventHandler, TransportUnicast,
+    TransportEventHandler, TransportManager, TransportMulticast, TransportMulticastEventHandler,
+    TransportPeer, TransportPeerEventHandler, TransportUnicast,
 };
 use zenoh_core::Result as ZResult;
+use zenoh_protocol_core::{EndPoint, WhatAmI};
 
 // Transport Handler for the peer
 struct MySH;
@@ -105,9 +105,15 @@ async fn main() {
 
     // Connect to the peer or listen
     if whatami == WhatAmI::Peer {
-        manager.add_listener(EndPoint::from_str(opt.endpoint.as_str()).unwrap()).await.unwrap();
+        manager
+            .add_listener(EndPoint::from_str(opt.endpoint.as_str()).unwrap())
+            .await
+            .unwrap();
     } else {
-        let _session = manager.open_transport(EndPoint::from_str(opt.endpoint.as_str()).unwrap()).await.unwrap();
+        let _session = manager
+            .open_transport(EndPoint::from_str(opt.endpoint.as_str()).unwrap())
+            .await
+            .unwrap();
     }
 
     // Stop forever

--- a/latency/src/bin/t_pong.rs
+++ b/latency/src/bin/t_pong.rs
@@ -14,7 +14,7 @@
 use async_std::future;
 use async_std::sync::Arc;
 use std::any::Any;
-use structopt::StructOpt;
+use clap::Parser;
 use zenoh::net::link::{EndPoint, Link};
 use zenoh::net::protocol::core::whatami;
 use zenoh::net::protocol::proto::ZenohMessage;
@@ -75,12 +75,15 @@ impl TransportPeerEventHandler for MyMH {
     }
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "s_sub_thr")]
+#[derive(Debug, Parser)]
+#[clap(name = "s_sub_thr")]
 struct Opt {
-    #[structopt(short = "l", long = "locator")]
-    locator: EndPoint,
-    #[structopt(short = "m", long = "mode")]
+    /// endpoint, e.g. --endpoint tcp/127.0.0.1:7447
+    #[clap(short, long)]
+    endpoint: String,
+
+    /// peer or client or router
+    #[clap(short, long)]
     mode: String,
 }
 
@@ -90,7 +93,7 @@ async fn main() {
     env_logger::init();
 
     // Parse the args
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     let whatami = whatami::parse(opt.mode.as_str()).unwrap();
 


### PR DESCRIPTION
* Edited `r_ping.rs` according to some suggestions in #10 PR10
* Replace structopt to clap in prefix "t_" files
* Update the usage of zenoh in prefix "t_" files 
* `Cargo fmt`

- [x] Compilation passed with command cargo build --bin t_ping (t_pong)

- [x]  Verified by the following commands: `./t_pong -e tcp/127.0.0.1:7447 -m peer` ,

`./t_ping -m peer -p 8 -n none -s none -i 1 -e tcp/127.0.0.1:7447`

- [x] Checked with `Cargo clippy`