### PR TITLE
Finished porting of "t_pub/sub_delay"

### DIFF
--- a/latency/src/bin/t_pub_delay.rs
+++ b/latency/src/bin/t_pub_delay.rs
@@ -14,7 +14,7 @@
 use async_std::sync::Arc;
 use async_std::task;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use structopt::StructOpt;
+use clap::Parser;
 use zenoh::net::link::EndPoint;
 use zenoh::net::protocol::core::{
     whatami, Channel, CongestionControl, Priority, Reliability, ResKey,
@@ -52,16 +52,23 @@ impl TransportEventHandler for MySH {
     }
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "z_ping")]
+#[derive(Debug, Parser)]
+#[clap(name = "t_pub_delay")]
 struct Opt {
-    #[structopt(short = "l", long = "locator")]
-    locator: EndPoint,
-    #[structopt(short = "m", long = "mode")]
+    /// endpoint, e.g. --endpoint tcp/127.0.0.1:7447
+    #[clap(short, long)]
+    endpoint: String,
+
+    /// peer or client or router
+    #[clap(short, long)]
     mode: String,
-    #[structopt(short = "p", long = "payload")]
+
+    /// payload size (bytes)
+    #[clap(short, long)]
     payload: usize,
-    #[structopt(short = "i", long = "interval")]
+
+    /// interval of sending message (sec)
+    #[clap(short, long)]
     interval: f64,
 }
 
@@ -71,7 +78,7 @@ async fn main() {
     env_logger::init();
 
     // Parse the args
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     let whatami = whatami::parse(opt.mode.as_str()).unwrap();
 

--- a/latency/src/bin/t_pub_delay.rs
+++ b/latency/src/bin/t_pub_delay.rs
@@ -13,19 +13,18 @@
 //
 use async_std::sync::Arc;
 use async_std::task;
+use std::str::FromStr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use clap::Parser;
-use zenoh::net::link::EndPoint;
-use zenoh::net::protocol::core::{
-    whatami, Channel, CongestionControl, Priority, Reliability, ResKey,
-};
+use zenoh_protocol_core::{Channel, CongestionControl, EndPoint, Priority, Reliability, WhatAmI};
 use zenoh::net::protocol::proto::ZenohMessage;
 use zenoh::net::transport::{
     DummyTransportPeerEventHandler, TransportEventHandler, TransportManager,
-    TransportManagerConfig, TransportMulticast, TransportMulticastEventHandler, TransportPeer,
+    TransportMulticast, TransportMulticastEventHandler, TransportPeer,
     TransportPeerEventHandler, TransportUnicast,
 };
-use zenoh_util::core::ZResult;
+use zenoh_core::Result as ZResult;
+
 
 struct MySH {}
 
@@ -63,7 +62,7 @@ struct Opt {
     #[clap(short, long)]
     mode: String,
 
-    /// payload size (bytes)
+    /// payload size ( >= 24 bytes)
     #[clap(short, long)]
     payload: usize,
 
@@ -80,15 +79,18 @@ async fn main() {
     // Parse the args
     let opt = Opt::parse();
 
-    let whatami = whatami::parse(opt.mode.as_str()).unwrap();
+    let whatami = WhatAmI::from_str(opt.mode.as_str()).unwrap();
 
-    let config = TransportManagerConfig::builder()
+    let manager = TransportManager::builder()
         .whatami(whatami)
-        .build(Arc::new(MySH::new()));
-    let manager = TransportManager::new(config);
+        .build(Arc::new(MySH::new()))
+        .unwrap();
 
     // Connect to publisher
-    let session = manager.open_transport(opt.locator).await.unwrap();
+    let session = manager
+        .open_transport(EndPoint::from_str(opt.endpoint.as_str()).unwrap())
+        .await
+        .unwrap();
 
     let mut count: u64 = 0;
     loop {
@@ -98,7 +100,7 @@ async fn main() {
             reliability: Reliability::Reliable,
         };
         let congestion_control = CongestionControl::Block;
-        let key = ResKey::RName("/test/ping".to_string());
+        let key = "/test/ping";
         let info = None;
         let routing_context = None;
         let reply_context = None;
@@ -106,6 +108,9 @@ async fn main() {
 
         // u64 (8 bytes) for seq num
         // u128 (16 bytes) for system time in nanoseconds
+        if opt.payload < 24 {
+            panic!("The payload size should >= 24");
+        }
         let mut payload = vec![0u8; opt.payload];
         let count_bytes: [u8; 8] = count.to_le_bytes();
         let now_bytes: [u8; 16] = SystemTime::now()
@@ -117,7 +122,7 @@ async fn main() {
         payload[8..24].copy_from_slice(&now_bytes);
 
         let message = ZenohMessage::make_data(
-            key,
+            key.into(),
             payload.into(),
             channel,
             congestion_control,

--- a/latency/src/bin/t_pub_delay.rs
+++ b/latency/src/bin/t_pub_delay.rs
@@ -13,18 +13,16 @@
 //
 use async_std::sync::Arc;
 use async_std::task;
+use clap::Parser;
 use std::str::FromStr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use clap::Parser;
-use zenoh_protocol_core::{Channel, CongestionControl, EndPoint, Priority, Reliability, WhatAmI};
 use zenoh::net::protocol::proto::ZenohMessage;
 use zenoh::net::transport::{
-    DummyTransportPeerEventHandler, TransportEventHandler, TransportManager,
-    TransportMulticast, TransportMulticastEventHandler, TransportPeer,
-    TransportPeerEventHandler, TransportUnicast,
+    DummyTransportPeerEventHandler, TransportEventHandler, TransportManager, TransportMulticast,
+    TransportMulticastEventHandler, TransportPeer, TransportPeerEventHandler, TransportUnicast,
 };
 use zenoh_core::Result as ZResult;
-
+use zenoh_protocol_core::{Channel, CongestionControl, EndPoint, Priority, Reliability, WhatAmI};
 
 struct MySH {}
 

--- a/latency/src/bin/t_sub_delay.rs
+++ b/latency/src/bin/t_sub_delay.rs
@@ -13,17 +13,17 @@
 //
 use async_std::future;
 use async_std::sync::Arc;
+use clap::Parser;
 use std::any::Any;
 use std::str::FromStr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use clap::Parser;
 use zenoh::net::link::Link;
 use zenoh::net::protocol::io::reader::{HasReader, Reader};
 use zenoh::net::protocol::io::SplitBuffer;
-use zenoh_protocol_core::{WhatAmI, EndPoint};
 use zenoh::net::protocol::proto::{Data, ZenohBody, ZenohMessage};
 use zenoh::net::transport::*;
 use zenoh_core::Result as ZResult;
+use zenoh_protocol_core::{EndPoint, WhatAmI};
 
 // Transport Handler for the peer
 struct MySH;
@@ -68,7 +68,9 @@ impl TransportPeerEventHandler for MyMH {
                 let mut now_bytes = [0u8; 16];
 
                 let mut data_reader = payload.reader();
-                if data_reader.read_exact(&mut count_bytes) && data_reader.read_exact(&mut now_bytes) {
+                if data_reader.read_exact(&mut count_bytes)
+                    && data_reader.read_exact(&mut now_bytes)
+                {
                     let count = u64::from_le_bytes(count_bytes);
                     let now_pub = u128::from_le_bytes(now_bytes);
 
@@ -119,7 +121,6 @@ async fn main() {
     let opt = Opt::parse();
 
     let whatami = WhatAmI::from_str(opt.mode.as_str()).unwrap();
-  
 
     let manager = TransportManager::builder()
         .whatami(whatami)
@@ -136,7 +137,7 @@ async fn main() {
         let _session = manager
             .open_transport(EndPoint::from_str(opt.endpoint.as_str()).unwrap())
             .await
-            .unwrap(); 
+            .unwrap();
     }
 
     // Stop forever

--- a/latency/src/bin/t_sub_delay.rs
+++ b/latency/src/bin/t_sub_delay.rs
@@ -14,13 +14,16 @@
 use async_std::future;
 use async_std::sync::Arc;
 use std::any::Any;
+use std::str::FromStr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use clap::Parser;
-use zenoh::net::link::{EndPoint, Link};
-use zenoh::net::protocol::core::whatami;
+use zenoh::net::link::Link;
+use zenoh::net::protocol::io::reader::{HasReader, Reader};
+use zenoh::net::protocol::io::SplitBuffer;
+use zenoh_protocol_core::{WhatAmI, EndPoint};
 use zenoh::net::protocol::proto::{Data, ZenohBody, ZenohMessage};
 use zenoh::net::transport::*;
-use zenoh_util::core::ZResult;
+use zenoh_core::Result as ZResult;
 
 // Transport Handler for the peer
 struct MySH;
@@ -60,22 +63,25 @@ impl MyMH {
 impl TransportPeerEventHandler for MyMH {
     fn handle_message(&self, message: ZenohMessage) -> ZResult<()> {
         match message.body {
-            ZenohBody::Data(Data { mut payload, .. }) => {
+            ZenohBody::Data(Data { payload, .. }) => {
                 let mut count_bytes = [0u8; 8];
-                payload.read_bytes(&mut count_bytes);
-                let count = u64::from_le_bytes(count_bytes);
-
                 let mut now_bytes = [0u8; 16];
-                payload.read_bytes(&mut now_bytes);
-                let now_pub = u128::from_le_bytes(now_bytes);
 
-                let now_sub = SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap()
-                    .as_nanos();
-                let interval = Duration::from_nanos((now_sub - now_pub) as u64);
+                let mut data_reader = payload.reader();
+                if data_reader.read_exact(&mut count_bytes) && data_reader.read_exact(&mut now_bytes) {
+                    let count = u64::from_le_bytes(count_bytes);
+                    let now_pub = u128::from_le_bytes(now_bytes);
 
-                println!("{} bytes: seq={} time={:?}", payload.len(), count, interval);
+                    let now_sub = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_nanos();
+                    let interval = Duration::from_nanos((now_sub - now_pub) as u64);
+
+                    println!("{} bytes: seq={} time={:?}", payload.len(), count, interval);
+                } else {
+                    panic!("Fail to fill the buffer");
+                }
             }
             _ => panic!("Invalid message"),
         }
@@ -112,18 +118,25 @@ async fn main() {
     // Parse the args
     let opt = Opt::parse();
 
-    let whatami = whatami::parse(opt.mode.as_str()).unwrap();
+    let whatami = WhatAmI::from_str(opt.mode.as_str()).unwrap();
+  
 
-    let config = TransportManagerConfig::builder()
+    let manager = TransportManager::builder()
         .whatami(whatami)
-        .build(Arc::new(MySH::new()));
-    let manager = TransportManager::new(config);
+        .build(Arc::new(MySH::new()))
+        .unwrap();
 
     // Connect to the peer or listen
-    if whatami == whatami::PEER {
-        manager.add_listener(opt.locator).await.unwrap();
+    if whatami == WhatAmI::Peer {
+        manager
+            .add_listener(EndPoint::from_str(opt.endpoint.as_str()).unwrap())
+            .await
+            .unwrap();
     } else {
-        let _session = manager.open_transport(opt.locator).await.unwrap();
+        let _session = manager
+            .open_transport(EndPoint::from_str(opt.endpoint.as_str()).unwrap())
+            .await
+            .unwrap(); 
     }
 
     // Stop forever

--- a/latency/src/bin/t_sub_delay.rs
+++ b/latency/src/bin/t_sub_delay.rs
@@ -15,7 +15,7 @@ use async_std::future;
 use async_std::sync::Arc;
 use std::any::Any;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use structopt::StructOpt;
+use clap::Parser;
 use zenoh::net::link::{EndPoint, Link};
 use zenoh::net::protocol::core::whatami;
 use zenoh::net::protocol::proto::{Data, ZenohBody, ZenohMessage};
@@ -92,12 +92,15 @@ impl TransportPeerEventHandler for MyMH {
     }
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "s_sub_thr")]
+#[derive(Debug, Parser)]
+#[clap(name = "t_sub_delay")]
 struct Opt {
-    #[structopt(short = "l", long = "locator")]
-    locator: EndPoint,
-    #[structopt(short = "m", long = "mode")]
+    /// endpoint, e.g. --endpoint tcp/127.0.0.1:7447
+    #[clap(short, long)]
+    endpoint: String,
+
+    /// peer or client or router
+    #[clap(short, long)]
     mode: String,
 }
 
@@ -107,7 +110,7 @@ async fn main() {
     env_logger::init();
 
     // Parse the args
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     let whatami = whatami::parse(opt.mode.as_str()).unwrap();
 


### PR DESCRIPTION
* Replace structopt to clap in `t_pub/sub_delay.rs`
* Update the usage of zenoh in `t_pub/sub_delay.rs`
* Add payload size checking (payload size should >= 24)
* Cargo fmt

- [x] Compilation passed with command cargo build --bin t_pub(sub)
_delay
- [x] Verified by the following commands: `./t_sub_delay -e tcp/127.0.0.1:7447 -m peer`,
`./t_ping -m peer -p 24 -i 1 -e tcp/127.0.0.1:7447`
- [x] Checked with Cargo clippy