### PR TITLE
Let the endpoints required for the command line arguments (throughput, latency)

### DIFF
--- a/latency/src/bin/t_pub_delay.rs
+++ b/latency/src/bin/t_pub_delay.rs
@@ -130,7 +130,7 @@ async fn main() {
             attachment,
         );
 
-        let _ = session.handle_message(message.clone()).unwrap();
+        session.handle_message(message.clone()).unwrap();
 
         task::sleep(Duration::from_secs_f64(opt.interval)).await;
         count += 1;

--- a/latency/src/bin/z_ping.rs
+++ b/latency/src/bin/z_ping.rs
@@ -27,7 +27,7 @@ use zenoh_protocol_core::{CongestionControl, WhatAmI};
 #[clap(name = "z_ping")]
 struct Opt {
     /// endpoint(s), e.g. --endpoint tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
-    #[clap(short, long)]
+    #[clap(short, long, required(true))]
     endpoint: Option<String>,
 
     /// peer or client

--- a/latency/src/bin/z_ping.rs
+++ b/latency/src/bin/z_ping.rs
@@ -90,10 +90,8 @@ async fn parallel(opt: Opt, config: Config) {
         if opt.declare_publication {
             session.declare_publication(key_expr_ping).await.unwrap();
         }
-    } else {
-        if opt.declare_publication {
-            session.declare_publication(KEY_EXPR_PING).await.unwrap();
-        }
+    } else if opt.declare_publication {
+        session.declare_publication(KEY_EXPR_PING).await.unwrap();
     }
     task::spawn(async move {
         while let Some(sample) = sub.next().await {
@@ -163,10 +161,8 @@ async fn single(opt: Opt, config: Config) {
         if opt.declare_publication {
             session.declare_publication(key_expr_ping).await.unwrap();
         }
-    } else {
-        if opt.declare_publication {
-            session.declare_publication("/test/ping").await.unwrap();
-        }
+    } else if opt.declare_publication {
+        session.declare_publication("/test/ping").await.unwrap();
     }
     let mut count: u64 = 0;
     loop {

--- a/latency/src/bin/z_pong.rs
+++ b/latency/src/bin/z_pong.rs
@@ -82,10 +82,8 @@ async fn main() {
         if opt.declare_publication {
             session.declare_publication(key_expr_pong).await.unwrap();
         }
-    } else {
-        if opt.declare_publication {
-            session.declare_publication(KEY_EXPR_PONG).await.unwrap();
-        }
+    } else if opt.declare_publication {
+        session.declare_publication(KEY_EXPR_PONG).await.unwrap();
     }
 
     while let Some(sample) = sub.next().await {

--- a/throughput/src/bin/r_pub_thr.rs
+++ b/throughput/src/bin/r_pub_thr.rs
@@ -34,7 +34,7 @@ use zenoh_protocol_core::{
 #[clap(name = "r_pub_thr")]
 struct Opt {
     /// endpoint(s), e.g. --endpoint tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
-    #[clap(short, long, value_delimiter = ',')]
+    #[clap(short, long, required(true), value_delimiter = ',')]
     endpoint: Vec<EndPoint>,
 
     /// peer, router, or client

--- a/throughput/src/bin/r_sub_thr.rs
+++ b/throughput/src/bin/r_sub_thr.rs
@@ -152,7 +152,7 @@ impl Primitives for ThroughputPrimitives {
 #[clap(name = "r_sub_thr")]
 struct Opt {
     /// endpoint(s), e.g. --endpoint tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
-    #[clap(short, long, value_delimiter = ',')]
+    #[clap(short, long, required(true), value_delimiter = ',')]
     endpoint: Vec<EndPoint>,
 
     /// peer, router, or client

--- a/throughput/src/bin/t_pub_thr.rs
+++ b/throughput/src/bin/t_pub_thr.rs
@@ -157,7 +157,7 @@ async fn main() {
                 reply_context.clone(),
                 attachment.clone(),
             );
-            let _ = t.handle_message(message).unwrap();
+            t.handle_message(message).unwrap();
         }
         count.fetch_add(1, Ordering::Relaxed);
     }

--- a/throughput/src/bin/t_pub_thr.rs
+++ b/throughput/src/bin/t_pub_thr.rs
@@ -66,7 +66,7 @@ impl TransportEventHandler for MySH {
 #[clap(name = "t_pub_thr")]
 struct Opt {
     /// endpoint(s), e.g. --endpoint tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
-    #[clap(short, long, value_delimiter = ',')]
+    #[clap(short, long, required(true), value_delimiter = ',')]
     endpoint: Vec<EndPoint>,
 
     /// peer, router, or client

--- a/throughput/src/bin/t_pubsub_thr.rs
+++ b/throughput/src/bin/t_pubsub_thr.rs
@@ -233,7 +233,7 @@ async fn main() {
                 reply_context.clone(),
                 attachment.clone(),
             );
-            let _ = t.handle_message(message).unwrap();
+            t.handle_message(message).unwrap();
         }
         count.fetch_add(1, Ordering::Relaxed);
     }

--- a/throughput/src/bin/t_pubsub_thr.rs
+++ b/throughput/src/bin/t_pubsub_thr.rs
@@ -174,6 +174,10 @@ async fn main() {
     let handler = Arc::new(MySH::new(scenario, name, payload, count));
     let manager = builder.build(handler).unwrap();
 
+    if listen.is_empty() && connect.is_empty() {
+        panic!("Either --listen or --connect needs to be specified, see --help for more details");
+    }
+
     // Connect to publisher
     for e in listen {
         let _ = manager.add_listener(e.clone()).await.unwrap();

--- a/throughput/src/bin/t_router_thr.rs
+++ b/throughput/src/bin/t_router_thr.rs
@@ -76,7 +76,9 @@ impl MyMH {
 
 impl TransportPeerEventHandler for MyMH {
     fn handle_message(&self, message: ZenohMessage) -> ZResult<()> {
-        for (i, e) in self.table.read().unwrap().iter() {
+        let read_table = self.table.read().unwrap();
+        let read_table = read_table.iter();
+        for (i, e) in read_table {
             if i != self.index {
                 let _ = e.handle_message(message.clone());
             }

--- a/throughput/src/bin/t_router_thr.rs
+++ b/throughput/src/bin/t_router_thr.rs
@@ -118,6 +118,10 @@ async fn main() {
         config,
     } = Opt::parse();
 
+    if listen.is_empty() && connect.is_empty() {
+        panic!("Either --listen or --connect needs to be specified, see --help for more details");
+    }
+
     // Create the session manager
     let builder = match config {
         Some(path) => TransportManager::builder()

--- a/throughput/src/bin/t_sink_tcp.rs
+++ b/throughput/src/bin/t_sink_tcp.rs
@@ -93,7 +93,7 @@ async fn handle_client(mut stream: TcpStream) -> Result<(), Box<dyn std::error::
                 attachment,
             );
             // Send the InitAck
-            let _ = zsend!(message, stream).unwrap();
+            zsend!(message, stream).unwrap();
         }
         _ => panic!(),
     }
@@ -107,7 +107,7 @@ async fn handle_client(mut stream: TcpStream) -> Result<(), Box<dyn std::error::
             let attachment = None;
             let mut message = TransportMessage::make_open_ack(*lease, *initial_sn, attachment);
             // Send the OpenAck
-            let _ = zsend!(message, stream).unwrap();
+            zsend!(message, stream).unwrap();
         }
         _ => panic!(),
     }

--- a/throughput/src/bin/t_sub_thr.rs
+++ b/throughput/src/bin/t_sub_thr.rs
@@ -121,7 +121,7 @@ impl TransportPeerEventHandler for MyMH {
 #[clap(name = "t_sub_thr")]
 struct Opt {
     /// endpoint(s), e.g. --endpoint tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
-    #[clap(short, long, value_delimiter = ',')]
+    #[clap(short, long, required(true), value_delimiter = ',')]
     endpoint: Vec<EndPoint>,
 
     /// peer, router, or client

--- a/throughput/src/bin/z_put_thr.rs
+++ b/throughput/src/bin/z_put_thr.rs
@@ -25,7 +25,7 @@ use zenoh_protocol_core::{CongestionControl, EndPoint, WhatAmI};
 #[clap(name = "z_put_thr")]
 struct Opt {
     /// endpoint(s), e.g. --endpoint tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
-    #[clap(short, long, value_delimiter = ',')]
+    #[clap(short, long, required(true), value_delimiter = ',')]
     endpoint: Vec<EndPoint>,
 
     /// peer, router, or client

--- a/throughput/src/bin/z_sub_thr.rs
+++ b/throughput/src/bin/z_sub_thr.rs
@@ -25,7 +25,7 @@ use zenoh_protocol_core::{EndPoint, WhatAmI};
 #[clap(name = "z_sub_thr")]
 struct Opt {
     /// endpoint(s), e.g. --endpoint tcp/127.0.0.1:7447,tcp/127.0.0.1:7448
-    #[clap(short, long, value_delimiter = ',')]
+    #[clap(short, long, required(true), value_delimiter = ',')]
     endpoint: Vec<EndPoint>,
 
     /// peer, router, or client


### PR DESCRIPTION
* Because the "multicast-scouting" is set to `false`, so the argument "endpoints" should set to "required" in clap's parser.  
